### PR TITLE
1.14 compatibility

### DIFF
--- a/src/main/java/world/bentobox/caveblock/CaveBlock.java
+++ b/src/main/java/world/bentobox/caveblock/CaveBlock.java
@@ -110,7 +110,7 @@ public class CaveBlock extends GameModeAddon
     @Override
     public void createWorlds()
     {
-        String worldName = this.settings.getWorldName();
+        String worldName = this.settings.getWorldName().toLowerCase();
 
         if (this.getServer().getWorld(worldName) == null)
         {

--- a/src/main/java/world/bentobox/caveblock/Settings.java
+++ b/src/main/java/world/bentobox/caveblock/Settings.java
@@ -19,7 +19,6 @@ import world.bentobox.bentobox.api.configuration.ConfigEntry;
 import world.bentobox.bentobox.api.configuration.StoreAt;
 import world.bentobox.bentobox.api.configuration.WorldSettings;
 import world.bentobox.bentobox.api.flags.Flag;
-import world.bentobox.bentobox.database.objects.DataObject;
 import world.bentobox.bentobox.database.objects.adapters.Adapter;
 import world.bentobox.bentobox.database.objects.adapters.FlagSerializer;
 import world.bentobox.bentobox.database.objects.adapters.FlagSerializer2;
@@ -755,27 +754,27 @@ public class Settings implements WorldSettings
     }
 
 
-	/**
-	 * This method returns the islandCommand value.
-	 * @return the value of islandCommand.
-	 */
-	public String getIslandCommand()
-	{
-		return islandCommand;
-	}
+    /**
+     * This method returns the islandCommand value.
+     * @return the value of islandCommand.
+     */
+    public String getIslandCommand()
+    {
+        return islandCommand;
+    }
 
 
-	/**
-	 * This method returns the adminCommand value.
-	 * @return the value of adminCommand.
-	 */
-	public String getAdminCommand()
-	{
-		return adminCommand;
-	}
+    /**
+     * This method returns the adminCommand value.
+     * @return the value of adminCommand.
+     */
+    public String getAdminCommand()
+    {
+        return adminCommand;
+    }
 
 
-	// ---------------------------------------------------------------------
+    // ---------------------------------------------------------------------
     // Section: Setters
     // ---------------------------------------------------------------------
 
@@ -1500,43 +1499,43 @@ public class Settings implements WorldSettings
     }
 
 
-	/**
-	 * This method sets the islandCommand value.
-	 * @param islandCommand the islandCommand new value.
-	 *
-	 */
-	public void setIslandCommand(String islandCommand)
-	{
-		this.islandCommand = islandCommand;
-	}
+    /**
+     * This method sets the islandCommand value.
+     * @param islandCommand the islandCommand new value.
+     *
+     */
+    public void setIslandCommand(String islandCommand)
+    {
+        this.islandCommand = islandCommand;
+    }
 
 
-	/**
-	 * This method sets the adminCommand value.
-	 * @param adminCommand the adminCommand new value.
-	 *
-	 */
-	public void setAdminCommand(String adminCommand)
-	{
-		this.adminCommand = adminCommand;
-	}
+    /**
+     * This method sets the adminCommand value.
+     * @param adminCommand the adminCommand new value.
+     *
+     */
+    public void setAdminCommand(String adminCommand)
+    {
+        this.adminCommand = adminCommand;
+    }
 
 
-	// ---------------------------------------------------------------------
+    // ---------------------------------------------------------------------
     // Section: Variables
     // ---------------------------------------------------------------------
 
 
-	/* Commands */
-	@ConfigComment("Cave Command. What command users will run to access their cave.")
-	@ConfigComment("To define alias, just separate commands with white space.")
-	@ConfigEntry(path = "cave.command.island")
-	private String islandCommand = "cave cb";
+    /* Commands */
+    @ConfigComment("Cave Command. What command users will run to access their cave.")
+    @ConfigComment("To define alias, just separate commands with white space.")
+    @ConfigEntry(path = "cave.command.island")
+    private String islandCommand = "cave cb";
 
-	@ConfigComment("The Cave admin command.")
-	@ConfigComment("To define alias, just separate commands with white space.")
-	@ConfigEntry(path = "cave.command.admin")
-	private String adminCommand = "cbadmin cba";
+    @ConfigComment("The Cave admin command.")
+    @ConfigComment("To define alias, just separate commands with white space.")
+    @ConfigEntry(path = "cave.command.admin")
+    private String adminCommand = "cbadmin cba";
 
     /*      WORLD       */
     @ConfigComment("Friendly name for this world. Used in admin commands. Must be a single word")
@@ -1546,7 +1545,7 @@ public class Settings implements WorldSettings
     @ConfigComment("Name of the world - if it does not exist then it will be generated.")
     @ConfigComment("It acts like a prefix for nether and end (e.g. CaveBlock-world, CaveBlock-world_nether, CaveBlock-world_end)")
     @ConfigEntry(path = "world.world-name")
-    private String worldName = "CaveBlock-world";
+    private String worldName = "caveblock-world";
 
     @ConfigComment("World difficulty setting - PEACEFUL, EASY, NORMAL, HARD")
     @ConfigComment("Other plugins may override this setting")

--- a/src/main/java/world/bentobox/caveblock/commands/AdminCommand.java
+++ b/src/main/java/world/bentobox/caveblock/commands/AdminCommand.java
@@ -5,10 +5,10 @@ import java.util.List;
 
 import world.bentobox.bentobox.api.commands.CompositeCommand;
 import world.bentobox.bentobox.api.commands.admin.*;
+import world.bentobox.bentobox.api.commands.admin.blueprints.AdminBlueprintCommand;
 import world.bentobox.bentobox.api.commands.admin.deaths.AdminDeathsCommand;
 import world.bentobox.bentobox.api.commands.admin.range.AdminRangeCommand;
 import world.bentobox.bentobox.api.commands.admin.resets.AdminResetsResetCommand;
-import world.bentobox.bentobox.api.commands.admin.schem.AdminSchemCommand;
 import world.bentobox.bentobox.api.commands.admin.team.AdminTeamAddCommand;
 import world.bentobox.bentobox.api.commands.admin.team.AdminTeamDisbandCommand;
 import world.bentobox.bentobox.api.commands.admin.team.AdminTeamKickCommand;
@@ -45,7 +45,7 @@ public class AdminCommand extends CompositeCommand {
         new AdminTeamDisbandCommand(this);
         new AdminTeamSetownerCommand(this);
         // Schems
-        new AdminSchemCommand(this);
+        new AdminBlueprintCommand(this);
         // Register/unregister islands
         new AdminRegisterCommand(this);
         new AdminUnregisterCommand(this);

--- a/src/main/java/world/bentobox/caveblock/generators/populators/MaterialPopulator.java
+++ b/src/main/java/world/bentobox/caveblock/generators/populators/MaterialPopulator.java
@@ -93,7 +93,8 @@ public class MaterialPopulator extends BlockPopulator
                         {
                             if (!block.getType().equals(entry.getKey()))
                             {
-                                block.setType(entry.getKey());
+                                // Set type without physics is required otherwise server goes into an infinite loop
+                                block.setType(entry.getKey(), false);
                                 packSize--;
                             }
 
@@ -123,7 +124,7 @@ public class MaterialPopulator extends BlockPopulator
                             block = chunk.getBlock(x, y, z);
 
                             continuePlacing = packSize > 0 && (block.getType().equals(chances.mainMaterial) ||
-                                block.getType().equals(entry.getKey()));
+                                    block.getType().equals(entry.getKey()));
                         }
                     }
                 }

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -12,7 +12,7 @@ world:
   friendly-name: CaveBlock
   # Name of the world - if it does not exist then it will be generated.
   # It acts like a prefix for nether and end (e.g. CaveBlock-world, CaveBlock-world_nether, CaveBlock-world_end)
-  world-name: CaveBlock-world
+  world-name: caveblock-world
   # World difficulty setting - PEACEFUL, EASY, NORMAL, HARD
   # Other plugins may override this setting
   difficulty: NORMAL


### PR DESCRIPTION
This makes the addon work on 1.14. There were 2 issues:

1. world creation needs to be done with a lower-case world. Note that this doesn't mean that a new world is created because world naming is apparently case-insensitive
2. The block populator was setting the block type with physics = true (the default). With 1.14 this would cause the server to go into some kind of infinite loop and freeze. Setting blocks with physics set to false fixed the issue.

https://github.com/BentoBoxWorld/CaveBlock/issues/22
