### PR TITLE
Do not check for blocks when looking for new islands.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -46,11 +46,11 @@
         <java.version>1.8</java.version>
         <!-- More visible way how to change dependency versions -->
         <spigot.version>1.16.4-R0.1-SNAPSHOT</spigot.version>
-        <bentobox.version>1.15.1</bentobox.version>
+        <bentobox.version>1.16.0-SNAPSHOT</bentobox.version>
         <!-- Revision variable removes warning about dynamic version -->
         <revision>${build.version}-SNAPSHOT</revision>
         <!-- This allows to change between versions and snapshots. -->
-        <build.version>1.14.2</build.version>
+        <build.version>1.14.3</build.version>
         <build.number>-LOCAL</build.number>
     </properties>
 

--- a/src/main/java/world/bentobox/caveblock/Settings.java
+++ b/src/main/java/world/bentobox/caveblock/Settings.java
@@ -1,7 +1,6 @@
 package world.bentobox.caveblock;
 
 
-import com.google.common.base.Enums;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -14,6 +13,8 @@ import org.bukkit.GameMode;
 import org.bukkit.Material;
 import org.bukkit.block.Biome;
 import org.bukkit.entity.EntityType;
+
+import com.google.common.base.Enums;
 
 import world.bentobox.bentobox.api.configuration.ConfigComment;
 import world.bentobox.bentobox.api.configuration.ConfigEntry;
@@ -1990,6 +1991,14 @@ public class Settings implements WorldSettings
         this.ticksPerMonsterSpawns = ticksPerMonsterSpawns;
     }
 
+    /* (non-Javadoc)
+     * @see world.bentobox.bentobox.api.configuration.WorldSettings#isCheckForBlocks()
+     */
+    @Override
+    public boolean isCheckForBlocks() {
+        // Do not check for blocks when looking for new island spots
+        return false;
+    }
 
 
     // ---------------------------------------------------------------------


### PR DESCRIPTION
https://github.com/BentoBoxWorld/BentoBox/issues/1694

Uses new WorldSetting to not search for blocks when making a new island.

To Do

- [ ] Test and confirm it works.