### PR TITLE
Refresh generators on config reload

### DIFF
--- a/src/main/java/world/bentobox/caveblock/CaveBlock.java
+++ b/src/main/java/world/bentobox/caveblock/CaveBlock.java
@@ -80,6 +80,11 @@ public class CaveBlock extends GameModeAddon
     {
         super.onReload();
         this.loadSettings();
+        // Refresh the generators so reloaded settings (world depth, materials, etc.)
+        // apply to newly generated chunks without a server restart.
+        this.chunkNormalGenerator.reload();
+        this.chunkNetherGenerator.reload();
+        this.chunkEndGenerator.reload();
     }
 
 

--- a/src/main/java/world/bentobox/caveblock/generators/ChunkGeneratorWorld.java
+++ b/src/main/java/world/bentobox/caveblock/generators/ChunkGeneratorWorld.java
@@ -40,7 +40,7 @@ public class ChunkGeneratorWorld extends ChunkGenerator {
     // -------------------------------------------------------------------------
 
     private final CaveBlock addon;
-    private final Settings settings;
+    private Settings settings;
     private final World.Environment environment;
     private final List<BlockPopulator> blockPopulators;
 
@@ -65,9 +65,13 @@ public class ChunkGeneratorWorld extends ChunkGenerator {
     // -------------------------------------------------------------------------
 
     /**
-     * Called when config is reloaded. Rebuilds block populators.
+     * Called when config is reloaded. Re-reads the live settings (a reload replaces
+     * the {@link Settings} instance) and rebuilds block populators so that changes
+     * such as world depth, roof/floor and main blocks take effect on newly
+     * generated chunks without a full server restart.
      */
     public void reload() {
+        this.settings = addon.getSettings();
         this.blockPopulators.clear();
         // Overworld uses vanilla decorations (shouldGenerateDecorations = true).
         // Nether and End use NewMaterialPopulator for ore/block placement.

--- a/src/test/java/world/bentobox/caveblock/CaveBlockTest.java
+++ b/src/test/java/world/bentobox/caveblock/CaveBlockTest.java
@@ -155,6 +155,8 @@ class CaveBlockTest extends CommonTestSetup {
      */
     @Test
     void testOnReload() {
+        // onReload refreshes the generators, which are created in onLoad().
+        addon.onLoad();
         addon.onReload();
         File check = new File("addons/CaveBlock", "config.yml");
         assertTrue(check.exists());


### PR DESCRIPTION
Fixes issue #3 from the #105 review.

## Problem
When the single chunk generator was split into three per-environment generators, `onReload()` stopped calling the generator reload that the old code did. As a result, after a `/caveblock reload`:
- `NewMaterialPopulator` kept the `worldDepth` captured at `onLoad`, so depth changes did not apply to newly generated nether/end chunks until a full restart.
- `ChunkGeneratorWorld` held the `Settings` instance captured at construction, but `loadSettings()` replaces it via `loadConfigObject()`, so roof/floor/main-block changes were also ignored on reload.

## Fix
- `onReload()` now calls `reload()` on all three generators.
- `ChunkGeneratorWorld.reload()` re-reads `addon.getSettings()` (the `settings` field is no longer `final`) before rebuilding its populators, so reloaded settings take effect on newly generated chunks without a restart.
- `testOnReload` now calls `onLoad()` first, matching the real addon lifecycle (generators exist before a reload). Includes the merged `testCreateWorlds` update from develop.

All 50 tests pass locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)