### PR TITLE
Configurable structure toggles for overworld cave generation (#112)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -50,7 +50,7 @@
         <!-- Revision variable removes warning about dynamic version -->
         <revision>${build.version}-SNAPSHOT</revision>
         <!-- This allows to change between versions and snapshots. -->
-        <build.version>1.22.0</build.version>
+        <build.version>1.23.0</build.version>
         <build.number>-LOCAL</build.number>
         <sonar.organization>bentobox-world</sonar.organization>
         <sonar.host.url>https://sonarcloud.io</sonar.host.url>

--- a/src/main/java/world/bentobox/caveblock/CaveBlock.java
+++ b/src/main/java/world/bentobox/caveblock/CaveBlock.java
@@ -19,6 +19,7 @@ import world.bentobox.bentobox.api.flags.Flag;
 import world.bentobox.caveblock.commands.IslandAboutCommand;
 import world.bentobox.caveblock.generators.ChunkGeneratorWorld;
 import world.bentobox.caveblock.listeners.CustomHeightLimitations;
+import world.bentobox.caveblock.listeners.StructureGenerationListener;
 
 
 public class CaveBlock extends GameModeAddon
@@ -67,8 +68,9 @@ public class CaveBlock extends GameModeAddon
         CaveBlock.SKY_WALKER_FLAG.addGameModeAddon(this);
         this.getPlugin().getFlagsManager().registerFlag(CaveBlock.SKY_WALKER_FLAG);
 
-        // Register listener
+        // Register listeners
         this.registerListener(new CustomHeightLimitations(this));
+        this.registerListener(new StructureGenerationListener(this));
     }
 
 

--- a/src/main/java/world/bentobox/caveblock/Settings.java
+++ b/src/main/java/world/bentobox/caveblock/Settings.java
@@ -5,6 +5,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -158,6 +159,18 @@ public class Settings implements WorldSettings
     @ConfigComment("Should not be less than cave height.")
     @ConfigEntry(path = "world.world-depth", needsReset = true)
     private int worldDepth = 319;
+
+    @ConfigComment("")
+    @ConfigComment("Vanilla structures that may generate in the overworld cave world.")
+    @ConfigComment("Set a structure to false to stop it generating; structures not listed here")
+    @ConfigComment("generate as normal. Use the vanilla structure key, for example:")
+    @ConfigComment("  ancient_city, trial_chambers, mineshaft, mineshaft_mesa, stronghold,")
+    @ConfigComment("  mansion, monument, pillager_outpost, ruined_portal, trail_ruins,")
+    @ConfigComment("  village_plains, desert_pyramid, jungle_pyramid, igloo, swamp_hut")
+    @ConfigComment("Large structures like Ancient Cities and Trial Chambers can fill or unbalance")
+    @ConfigComment("a cave world, so they are disabled by default. Only affects the overworld.")
+    @ConfigEntry(path = "world.structures", since = "1.23.0")
+    private Map<String, Boolean> generateStructures = defaultStructures();
 
     @ConfigComment("")
     @ConfigComment("Make over world roof of bedrock, if false, it will be made from stone.")
@@ -1194,6 +1207,46 @@ public class Settings implements WorldSettings
     public int getWorldDepth()
     {
         return worldDepth;
+    }
+
+
+    /**
+     * Map of vanilla structure key to whether it may generate in the overworld.
+     * A structure explicitly mapped to {@code false} is prevented from generating;
+     * any structure not present in the map generates normally.
+     * @return the structure generation map.
+     */
+    public Map<String, Boolean> getGenerateStructures()
+    {
+        return generateStructures;
+    }
+
+
+    /**
+     * Sets the structure generation map.
+     * @param generateStructures the structure generation map.
+     */
+    public void setGenerateStructures(Map<String, Boolean> generateStructures)
+    {
+        this.generateStructures = generateStructures;
+    }
+
+
+    /**
+     * Default structure toggles. Large, disruptive structures that tend to fill or
+     * unbalance a cave world are disabled; the common smaller ones are left on so
+     * the entry is self-documenting.
+     * @return an ordered map of structure key to whether it generates.
+     */
+    private static Map<String, Boolean> defaultStructures()
+    {
+        Map<String, Boolean> map = new LinkedHashMap<>();
+        map.put("ancient_city", false);
+        map.put("trial_chambers", false);
+        map.put("mansion", false);
+        map.put("mineshaft", true);
+        map.put("stronghold", true);
+        return map;
     }
 
 

--- a/src/main/java/world/bentobox/caveblock/listeners/StructureGenerationListener.java
+++ b/src/main/java/world/bentobox/caveblock/listeners/StructureGenerationListener.java
@@ -1,0 +1,81 @@
+package world.bentobox.caveblock.listeners;
+
+import java.util.Locale;
+import java.util.Map;
+
+import org.bukkit.World;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.EventPriority;
+import org.bukkit.event.Listener;
+import org.bukkit.event.world.AsyncStructureSpawnEvent;
+
+import world.bentobox.caveblock.CaveBlock;
+
+/**
+ * Prevents configured vanilla structures from generating in the CaveBlock
+ * overworld.
+ *
+ * <p>The overworld delegates to vanilla generation, which includes structures
+ * such as Ancient Cities, Trial Chambers and Strongholds. Some of these fill or
+ * unbalance a cave world (see issue #112). The {@link org.bukkit.generator.ChunkGenerator}
+ * flag can only turn all structures on or off, so this listener provides
+ * per-structure control by cancelling the spawn of any structure the admin has
+ * disabled in {@code world.structures}.</p>
+ *
+ * <p>{@link AsyncStructureSpawnEvent} fires off the main thread during chunk
+ * generation, so this handler only reads config and inspects the event — it
+ * performs no Bukkit world access.</p>
+ *
+ * @author tastybento
+ */
+public class StructureGenerationListener implements Listener {
+
+    private final CaveBlock addon;
+
+    /**
+     * @param addon CaveBlock addon
+     */
+    public StructureGenerationListener(CaveBlock addon) {
+        this.addon = addon;
+    }
+
+    /**
+     * Cancels the spawn of a disabled structure in the CaveBlock overworld.
+     *
+     * @param event the structure spawn event
+     */
+    @EventHandler(priority = EventPriority.NORMAL, ignoreCancelled = true)
+    public void onStructureSpawn(AsyncStructureSpawnEvent event) {
+        World world = event.getWorld();
+        // Only the CaveBlock overworld uses vanilla structures; nether/end do not.
+        if (world.getEnvironment() != World.Environment.NORMAL || !addon.inWorld(world)) {
+            return;
+        }
+        String structureKey = event.getStructure().getKey().getKey();
+        if (isDisabled(structureKey)) {
+            event.setCancelled(true);
+        }
+    }
+
+    /**
+     * @param structureKey the vanilla structure key path, e.g. {@code ancient_city}
+     * @return {@code true} if the config explicitly disables this structure
+     */
+    private boolean isDisabled(String structureKey) {
+        Map<String, Boolean> structures = addon.getSettings().getGenerateStructures();
+        if (structures == null || structures.isEmpty()) {
+            return false;
+        }
+        for (Map.Entry<String, Boolean> entry : structures.entrySet()) {
+            // Accept hyphen or underscore separators and any casing.
+            if (normalize(entry.getKey()).equals(structureKey) && Boolean.FALSE.equals(entry.getValue())) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private String normalize(String key) {
+        return key.toLowerCase(Locale.ROOT).replace('-', '_');
+    }
+}

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -91,6 +91,22 @@ world:
   # Should not be less than cave height.
   # /!\ BentoBox currently does not support changing this value mid-game. If you do need to change it, do a full reset of your databases and worlds.
   world-depth: 319
+  #
+  # Vanilla structures that may generate in the overworld cave world.
+  # Set a structure to false to stop it generating; structures not listed here
+  # generate as normal. Use the vanilla structure key, for example:
+  #   ancient_city, trial_chambers, mineshaft, mineshaft_mesa, stronghold,
+  #   mansion, monument, pillager_outpost, ruined_portal, trail_ruins,
+  #   village_plains, desert_pyramid, jungle_pyramid, igloo, swamp_hut
+  # Large structures like Ancient Cities and Trial Chambers can fill or unbalance
+  # a cave world, so they are disabled by default. Only affects the overworld.
+  # Added since 1.23.0.
+  structures:
+    ancient_city: false
+    trial_chambers: false
+    mansion: false
+    mineshaft: true
+    stronghold: true
   normal:
     # Make over world roof of bedrock. If false, it will be made from the main block (stone).
     # /!\ BentoBox currently does not support changing this value mid-game. If you do need to change it, do a full reset of your databases and worlds.

--- a/src/test/java/world/bentobox/caveblock/listeners/StructureGenerationListenerTest.java
+++ b/src/test/java/world/bentobox/caveblock/listeners/StructureGenerationListenerTest.java
@@ -1,0 +1,110 @@
+package world.bentobox.caveblock.listeners;
+
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.Map;
+
+import org.bukkit.NamespacedKey;
+import org.bukkit.World;
+import org.bukkit.event.world.AsyncStructureSpawnEvent;
+import org.bukkit.generator.structure.Structure;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockbukkit.mockbukkit.MockBukkit;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import world.bentobox.caveblock.CaveBlock;
+import world.bentobox.caveblock.Settings;
+
+/**
+ * Tests for {@link StructureGenerationListener}.
+ */
+@ExtendWith(MockitoExtension.class)
+class StructureGenerationListenerTest {
+
+    @Mock
+    private CaveBlock addon;
+    @Mock
+    private Settings settings;
+    @Mock
+    private World world;
+
+    private StructureGenerationListener listener;
+
+    @BeforeEach
+    public void setUp() {
+        MockBukkit.mock();
+        lenient().when(addon.getSettings()).thenReturn(settings);
+        lenient().when(settings.getGenerateStructures())
+                .thenReturn(Map.of("ancient_city", false, "trial_chambers", false, "mineshaft", true));
+        lenient().when(addon.inWorld(world)).thenReturn(true);
+        lenient().when(world.getEnvironment()).thenReturn(World.Environment.NORMAL);
+        listener = new StructureGenerationListener(addon);
+    }
+
+    @AfterEach
+    public void tearDown() {
+        MockBukkit.unmock();
+    }
+
+    private AsyncStructureSpawnEvent event(String structureKey) {
+        Structure structure = mock(Structure.class);
+        lenient().when(structure.getKey()).thenReturn(NamespacedKey.minecraft(structureKey));
+        AsyncStructureSpawnEvent e = mock(AsyncStructureSpawnEvent.class);
+        lenient().when(e.getWorld()).thenReturn(world);
+        lenient().when(e.getStructure()).thenReturn(structure);
+        return e;
+    }
+
+    @Test
+    void testDisabledStructureIsCancelled() {
+        AsyncStructureSpawnEvent e = event("ancient_city");
+        listener.onStructureSpawn(e);
+        verify(e).setCancelled(true);
+    }
+
+    @Test
+    void testEnabledStructureIsNotCancelled() {
+        AsyncStructureSpawnEvent e = event("mineshaft");
+        listener.onStructureSpawn(e);
+        verify(e, never()).setCancelled(true);
+    }
+
+    @Test
+    void testUnlistedStructureGeneratesNormally() {
+        AsyncStructureSpawnEvent e = event("village_plains");
+        listener.onStructureSpawn(e);
+        verify(e, never()).setCancelled(true);
+    }
+
+    @Test
+    void testStructureOutsideCaveBlockWorldIsIgnored() {
+        when(addon.inWorld(world)).thenReturn(false);
+        AsyncStructureSpawnEvent e = event("ancient_city");
+        listener.onStructureSpawn(e);
+        verify(e, never()).setCancelled(true);
+    }
+
+    @Test
+    void testNetherEnvironmentIsIgnored() {
+        when(world.getEnvironment()).thenReturn(World.Environment.NETHER);
+        AsyncStructureSpawnEvent e = event("ancient_city");
+        listener.onStructureSpawn(e);
+        verify(e, never()).setCancelled(true);
+    }
+
+    @Test
+    void testConfigKeyWithHyphensAndCaseMatches() {
+        when(settings.getGenerateStructures()).thenReturn(Map.of("Ancient-City", false));
+        AsyncStructureSpawnEvent e = event("ancient_city");
+        listener.onStructureSpawn(e);
+        verify(e).setCancelled(true);
+    }
+}


### PR DESCRIPTION
Fixes #112.

The CaveBlock overworld delegates to vanilla generation, which includes structures like **Ancient Cities**, **Trial Chambers** and **Strongholds**. Some of these fill or unbalance a cave world — the issue shows an Ancient City taking over almost an entire cave area. Bukkit's `ChunkGenerator` structure flag is all-or-nothing, so this adds **per-structure** control.

## What changed

### `world.structures` config (Map<String, Boolean>)
```yaml
world:
  structures:
    ancient_city: false
    trial_chambers: false
    mansion: false
    mineshaft: true
    stronghold: true
```
- Each entry maps a vanilla structure key to whether it may generate.
- **Structures not listed generate as normal**, so this is non-invasive.
- Defaults disable the big disruptive ones (`ancient_city`, `trial_chambers`, `mansion`) and leave common ones on.
- Only affects the overworld (nether/end don't generate vanilla structures here).

### `StructureGenerationListener`
Cancels `AsyncStructureSpawnEvent` for any disabled structure in the CaveBlock overworld. The event is async and the handler only reads config + inspects the event (no world access), so it's thread-safe. Key matching tolerates hyphens and casing (e.g. `Ancient-City` matches `ancient_city`).

### Also
- `config.yml` documents the new section with the list of accepted structure keys.
- `pom.xml` — bump `build.version` to **1.23.0**.

## Notes
- BentoBox requires both a getter **and setter** for `@ConfigEntry` fields; both are provided for the new map.
- Admins can re-enable any structure by setting it to `true` or removing its entry.

## Tests
Added `StructureGenerationListenerTest` (disabled cancelled, enabled/unlisted allowed, non-CaveBlock world ignored, nether ignored, hyphen/case matching). All 67 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KxBgEZz7yHf4eLVzJTw1V5