### PR TITLE
Stop /locate freezing the server for disabled structures (#116)

### DIFF
--- a/src/main/java/world/bentobox/caveblock/listeners/StructureGenerationListener.java
+++ b/src/main/java/world/bentobox/caveblock/listeners/StructureGenerationListener.java
@@ -1,5 +1,6 @@
 package world.bentobox.caveblock.listeners;
 
+import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 
@@ -8,7 +9,9 @@ import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
 import org.bukkit.event.Listener;
 import org.bukkit.event.world.AsyncStructureSpawnEvent;
+import org.bukkit.generator.structure.Structure;
 
+import io.papermc.paper.event.world.StructuresLocateEvent;
 import world.bentobox.caveblock.CaveBlock;
 
 /**
@@ -23,9 +26,16 @@ import world.bentobox.caveblock.CaveBlock;
  * disabled in {@code world.structures}.</p>
  *
  * <p>{@link AsyncStructureSpawnEvent} fires off the main thread during chunk
- * generation, so this handler only reads config and inspects the event. It
+ * generation, so that handler only reads config and inspects the event. It
  * queries the event's world for environment and ownership checks but performs
  * no world or block mutation, which is what makes it safe to run async.</p>
+ *
+ * <p>Cancelling the spawn stops a structure being <em>placed</em> but leaves its
+ * placement rules intact, so structure <em>searches</em> ({@code /locate}, Eyes of
+ * Ender, treasure/explorer maps, villager map trades) keep proposing candidate
+ * positions that are then all cancelled, scanning to the radius cap and freezing
+ * the server (issue #116). {@link #onStructuresLocate} closes that hole by removing
+ * disabled structures from the search before it runs.</p>
  *
  * @author tastybento
  */
@@ -55,6 +65,38 @@ public class StructureGenerationListener implements Listener {
         String structureKey = event.getStructure().getKey().getKey();
         if (isDisabled(structureKey)) {
             event.setCancelled(true);
+        }
+    }
+
+    /**
+     * Prevents disabled structures from being <em>located</em>. {@link StructuresLocateEvent}
+     * fires before any structure search — the {@code /locate} command, Eyes of Ender,
+     * explorer/treasure maps, dolphins and villager map trades. On a cave world where the
+     * target structure is suppressed, that search never succeeds and scans out to the radius
+     * cap, freezing the main thread (issue #116). Removing the disabled structures from the
+     * search list — and cancelling outright when nothing remains — skips the scan entirely so
+     * the search returns "not found" instantly.
+     *
+     * @param event the structure locate event
+     */
+    @EventHandler(priority = EventPriority.NORMAL, ignoreCancelled = true)
+    public void onStructuresLocate(StructuresLocateEvent event) {
+        if (!addon.inWorld(event.getWorld())) {
+            return;
+        }
+        List<Structure> targets = event.getStructures();
+        List<Structure> allowed = targets.stream()
+                .filter(structure -> !isDisabled(structure.getKey().getKey()))
+                .toList();
+        if (allowed.size() == targets.size()) {
+            // Nothing disabled in this search — let it run normally.
+            return;
+        }
+        if (allowed.isEmpty()) {
+            // Every requested structure is disabled here: skip the expensive scan entirely.
+            event.setCancelled(true);
+        } else {
+            event.setStructures(allowed);
         }
     }
 

--- a/src/test/java/world/bentobox/caveblock/listeners/StructureGenerationListenerTest.java
+++ b/src/test/java/world/bentobox/caveblock/listeners/StructureGenerationListenerTest.java
@@ -1,11 +1,15 @@
 package world.bentobox.caveblock.listeners;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import java.util.Arrays;
+import java.util.List;
 import java.util.Map;
 
 import org.bukkit.NamespacedKey;
@@ -17,9 +21,11 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockbukkit.mockbukkit.MockBukkit;
+import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import io.papermc.paper.event.world.StructuresLocateEvent;
 import world.bentobox.caveblock.CaveBlock;
 import world.bentobox.caveblock.Settings;
 
@@ -106,5 +112,54 @@ class StructureGenerationListenerTest {
         AsyncStructureSpawnEvent e = event("ancient_city");
         listener.onStructureSpawn(e);
         verify(e).setCancelled(true);
+    }
+
+    private StructuresLocateEvent locateEvent(String... structureKeys) {
+        List<Structure> structures = Arrays.stream(structureKeys).map(key -> {
+            Structure structure = mock(Structure.class);
+            lenient().when(structure.getKey()).thenReturn(NamespacedKey.minecraft(key));
+            return structure;
+        }).map(Structure.class::cast).toList();
+        StructuresLocateEvent e = mock(StructuresLocateEvent.class);
+        lenient().when(e.getWorld()).thenReturn(world);
+        lenient().when(e.getStructures()).thenReturn(structures);
+        return e;
+    }
+
+    @Test
+    void testLocateAllDisabledIsCancelled() {
+        StructuresLocateEvent e = locateEvent("trial_chambers");
+        listener.onStructuresLocate(e);
+        verify(e).setCancelled(true);
+        verify(e, never()).setStructures(anyList());
+    }
+
+    @Test
+    void testLocateMixedNarrowsToEnabledOnly() {
+        StructuresLocateEvent e = locateEvent("trial_chambers", "mineshaft");
+        listener.onStructuresLocate(e);
+        verify(e, never()).setCancelled(true);
+        @SuppressWarnings("unchecked")
+        ArgumentCaptor<List<Structure>> captor = ArgumentCaptor.forClass(List.class);
+        verify(e).setStructures(captor.capture());
+        assertEquals(1, captor.getValue().size());
+        assertEquals("mineshaft", captor.getValue().get(0).getKey().getKey());
+    }
+
+    @Test
+    void testLocateAllEnabledIsUntouched() {
+        StructuresLocateEvent e = locateEvent("mineshaft", "village_plains");
+        listener.onStructuresLocate(e);
+        verify(e, never()).setCancelled(true);
+        verify(e, never()).setStructures(anyList());
+    }
+
+    @Test
+    void testLocateOutsideCaveBlockWorldIsIgnored() {
+        when(addon.inWorld(world)).thenReturn(false);
+        StructuresLocateEvent e = locateEvent("trial_chambers");
+        listener.onStructuresLocate(e);
+        verify(e, never()).setCancelled(true);
+        verify(e, never()).setStructures(anyList());
     }
 }


### PR DESCRIPTION
## Problem

Part of #116. Disabling a structure via `world.structures` cancels its `AsyncStructureSpawnEvent` so it is never **placed** — but that leaves the world's structure **placement rules** intact. Every structure search keeps proposing candidate positions that are then all cancelled, so the search can never succeed and scans outward to the radius cap.

This affects the whole search family, per `StructuresLocateEvent`'s own javadoc:
- the `/locate` command
- Eyes of Ender
- explorer / treasure maps
- dolphins swimming to treasure
- **villager map trades** (cartographer)

On a local test world, `/locate structure minecraft:trial_chambers` generated **~1,500** cancelled trial-chamber structure starts, scanning ~±9,000 blocks, and **froze the main thread for 62 seconds**, tripping the Paper Watchdog:

```
Locating element minecraft:trial_chambers took 62098 ms
[Paper Watchdog Thread/ERROR]: ... consider increasing timeout-time in spigot.yml ...
```

## Fix

Handle `io.papermc.paper.event.world.StructuresLocateEvent`, which Paper fires **before** any structure search. In a CaveBlock world:

- Remove disabled structures from the search target list.
- If nothing enabled remains, cancel the event so the expensive scan is skipped entirely — the search returns "not found" instantly.
- Mixed searches (e.g. a tag covering enabled + disabled structures) are narrowed to only the enabled ones.

Enabled structures, and searches in other worlds, are untouched. This sits alongside the existing `AsyncStructureSpawnEvent` handler:
- `AsyncStructureSpawnEvent` → stops physical generation
- `StructuresLocateEvent` → stops the search freeze

## Testing

- Verified on a local Paper/Purpur 1.21.11 server: `/locate structure minecraft:trial_chambers` now returns immediately instead of freezing for 62 s, with no flood of cancelled spawn events and no Watchdog error.
- Added unit tests: all-disabled → cancelled; mixed → narrowed to enabled; all-enabled → untouched; outside the CaveBlock world → ignored.

## Not covered here (follow-up)

The other half of #116 — a structure still generating in the **initial spawn pre-gen area** — stems from `createWorlds()` running before `onEnable()`, where the listener is registered, so the first chunks generate before suppression is active. That fix (register the listener before world creation) is a separate change and will follow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)