### PR TITLE
Suppress structures in the spawn area too (#116)

### DIFF
--- a/src/main/java/world/bentobox/caveblock/CaveBlock.java
+++ b/src/main/java/world/bentobox/caveblock/CaveBlock.java
@@ -70,7 +70,8 @@ public class CaveBlock extends GameModeAddon
 
         // Register listeners
         this.registerListener(new CustomHeightLimitations(this));
-        this.registerListener(new StructureGenerationListener(this));
+        // StructureGenerationListener is registered earlier, in createWorlds(), so it is
+        // active before the first chunks (including the spawn area) are generated.
     }
 
 
@@ -138,6 +139,11 @@ public class CaveBlock extends GameModeAddon
     @Override
     public void createWorlds()
     {
+        // Register the structure listener before any world is created. createWorlds() runs
+        // before onEnable(), and generating a world also generates its spawn-area chunks, so a
+        // listener registered in onEnable() would miss those first structures (issue #116).
+        this.registerListener(new StructureGenerationListener(this));
+
         String worldName = this.settings.getWorldName().toLowerCase();
 
         if (this.getServer().getWorld(worldName) == null)

--- a/src/main/java/world/bentobox/caveblock/listeners/StructureGenerationListener.java
+++ b/src/main/java/world/bentobox/caveblock/listeners/StructureGenerationListener.java
@@ -57,9 +57,8 @@ public class StructureGenerationListener implements Listener {
      */
     @EventHandler(priority = EventPriority.NORMAL, ignoreCancelled = true)
     public void onStructureSpawn(AsyncStructureSpawnEvent event) {
-        World world = event.getWorld();
         // Only the CaveBlock overworld uses vanilla structures; nether/end do not.
-        if (world.getEnvironment() != World.Environment.NORMAL || !addon.inWorld(world)) {
+        if (!isCaveOverworld(event.getWorld())) {
             return;
         }
         String structureKey = event.getStructure().getKey().getKey();
@@ -81,7 +80,7 @@ public class StructureGenerationListener implements Listener {
      */
     @EventHandler(priority = EventPriority.NORMAL, ignoreCancelled = true)
     public void onStructuresLocate(StructuresLocateEvent event) {
-        if (!addon.inWorld(event.getWorld())) {
+        if (!isCaveOverworld(event.getWorld())) {
             return;
         }
         List<Structure> targets = event.getStructures();
@@ -98,6 +97,24 @@ public class StructureGenerationListener implements Listener {
         } else {
             event.setStructures(allowed);
         }
+    }
+
+    /**
+     * @param world a world
+     * @return {@code true} if {@code world} is the CaveBlock overworld.
+     *
+     * <p>Matches on the configured world name rather than {@link CaveBlock#inWorld(World)}
+     * because structures in the spawn area are generated during {@code createWorlds()},
+     * before the addon's island-world reference is assigned. At that point
+     * {@code inWorld()} would compare against a null world and fail, so the first
+     * structures would slip through (issue #116).</p>
+     */
+    private boolean isCaveOverworld(World world) {
+        if (world.getEnvironment() != World.Environment.NORMAL) {
+            return false;
+        }
+        String configuredName = addon.getSettings().getWorldName();
+        return configuredName != null && world.getName().equalsIgnoreCase(configuredName);
     }
 
     /**

--- a/src/test/java/world/bentobox/caveblock/listeners/StructureGenerationListenerTest.java
+++ b/src/test/java/world/bentobox/caveblock/listeners/StructureGenerationListenerTest.java
@@ -50,7 +50,8 @@ class StructureGenerationListenerTest {
         lenient().when(addon.getSettings()).thenReturn(settings);
         lenient().when(settings.getGenerateStructures())
                 .thenReturn(Map.of("ancient_city", false, "trial_chambers", false, "mineshaft", true));
-        lenient().when(addon.inWorld(world)).thenReturn(true);
+        lenient().when(settings.getWorldName()).thenReturn("caveblock_world");
+        lenient().when(world.getName()).thenReturn("caveblock_world");
         lenient().when(world.getEnvironment()).thenReturn(World.Environment.NORMAL);
         listener = new StructureGenerationListener(addon);
     }
@@ -92,7 +93,7 @@ class StructureGenerationListenerTest {
 
     @Test
     void testStructureOutsideCaveBlockWorldIsIgnored() {
-        when(addon.inWorld(world)).thenReturn(false);
+        when(world.getName()).thenReturn("some_other_world");
         AsyncStructureSpawnEvent e = event("ancient_city");
         listener.onStructureSpawn(e);
         verify(e, never()).setCancelled(true);
@@ -156,7 +157,7 @@ class StructureGenerationListenerTest {
 
     @Test
     void testLocateOutsideCaveBlockWorldIsIgnored() {
-        when(addon.inWorld(world)).thenReturn(false);
+        when(world.getName()).thenReturn("some_other_world");
         StructuresLocateEvent e = locateEvent("trial_chambers");
         listener.onStructuresLocate(e);
         verify(e, never()).setCancelled(true);


### PR DESCRIPTION
## Problem

Follow-up to #117, closing the other half of #116: a **disabled structure could still generate near spawn**.

`StructureGenerationListener` was registered in `onEnable()`, but BentoBox calls `createWorlds()` **before** `onEnable()`, and creating a world also generates its spawn-area chunks. Those first structures were placed before the listener existed, so they escaped suppression. This matches the reporter finding a trial chamber despite `trial_chambers: false`, and the debug run where the listener registered ~5 s *after* `Creating CaveBlock world ...`.

## Fix

Register the listener at the **start of `createWorlds()`**, before any world is created, so it is active for the initial spawn generation.

That alone isn't sufficient: `createWorlds()` assigns `islandWorld` from the return value of `createWorld()`, so `islandWorld` is still `null` while the spawn chunks generate. The async `AsyncStructureSpawnEvent` handler calling `addon.inWorld(world)` would then compare against a null world (`Util.sameWorld` → `stripName(null)` → NPE) and silently fail to cancel.

So both handlers now match on the **configured world name** via a new `isCaveOverworld()` helper instead of `inWorld()`, removing the dependency on the not-yet-assigned world reference.

## Testing

- `mvn test` — all 78 pass. The listener tests were updated to match on world name (`getWorldName()` / `World#getName()`) rather than `inWorld()`.
- Manual verification on Paper/Purpur 1.21.11 with a freshly deleted world.

## Note

Structures already written to region files by a previous run are unaffected — clearing them needs a world reset.

🤖 Generated with [Claude Code](https://claude.com/claude-code)